### PR TITLE
Fix/node modules issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ mounting.
 You can find issues when docker builds the image if the volumes are
 mounted after a build from the empty host as it will write over the build. 
 
+If not clear, read [this](https://stackoverflow.com/questions/30043872/docker-compose-node-modules-not-present-in-a-volume-after-npm-install-succeeds)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+Dockerfiles for Codelitt Docker images
+===========
+
+#Node images
+Specify your volumes in docker-compose as such
+```
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    volumes:
+      - ./:/share
+      - /share/node_modules
+```
+
+Here is a full example of a dockerfile we use for the front end of codelitt.com:
+
+```
+version: '2'
+services:
+  frontend:
+    container_name: codelitt-v2
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    volumes:
+      - ./:/share
+      - /share/node_modules
+    ports:
+      - "8080:8080"
+```
+
+This uses a data volume to store all the `node_modules` as data 
+volumes copy in the data from the built docker image before 
+mounting. 
+
+You can find issues when docker builds the image if the volumes are
+mounted after a build from the empty host as it will write over the build. 
+
+

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,9 +1,5 @@
 FROM phusion/baseimage
 
-# Mount any shared volumes from host to container @ /share
-VOLUME ["/share"]
-WORKDIR /share
-
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
- Basically using Codelitt standard processes and docker-compose
files, creating a volume and twice basically meant that we were
mounting a blank node_modules over the previously built image.
- This fixes that. Specify your volumes in docker-compose as such
```
    build:
      context: .
      dockerfile: Dockerfile.development
    volumes:
      - ./:/share
      - /share/node_modules
```

- This uses a data volume to store all the node_modules as data
volumes copy in the data from the built docker image before
mounting.