### PR TITLE
remove bundle install from ruby 2.4 onbuild dockerfile

### DIFF
--- a/ruby/2.4/onbuild/prod/Dockerfile
+++ b/ruby/2.4/onbuild/prod/Dockerfile
@@ -6,6 +6,5 @@ RUN bundle config --global frozen 1
 
 ONBUILD COPY Gemfile /share/
 ONBUILD COPY Gemfile.lock /share/
-ONBUILD RUN bundle install
 
 ONBUILD COPY . /share


### PR DESCRIPTION
Running bundle install using ONBUILD commands does not give the child images the chance to set up dependencies that some of the gems specific for some projects might require.