### PR TITLE
Adds support to build Go module Docker image and update the Go stack

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p $GOPATH/src/app
 WORKDIR $GOPATH/src/app
 ADD . .
 
+RUN go get ./...
 RUN GO111MODULE=off GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-w -s"  -o $GOPATH/src/app
 
 FROM alpine:3.9 as ca

--- a/go/Dockerfile-module
+++ b/go/Dockerfile-module
@@ -1,10 +1,11 @@
 FROM golang:1.12-alpine as builder
 
-RUN mkdir -p $GOPATH/src/app
-WORKDIR $GOPATH/src/app
+RUN mkdir -p /app
+WORKDIR /app
 ADD . .
 
-RUN GO111MODULE=off GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-w -s"  -o $GOPATH/src/app
+# remove "-mod vendor" for none vendored repo
+RUN GO111MODULE=on GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-w -s"  -mod vendor -o /app/app
 
 FROM alpine:3.9 as ca
 RUN adduser -D -g '' appuser

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,16 @@
+# Golang Dockerfiles
+
+Provides boilerplate Dockerfiles to work with modern go application.
+Using the power of multistage build. 
+
+It expects the code to be in the same folder as the docker files
+
+# To use it 
+
+- Go mod (vendored packages):
+    
+        `docker build -f Dockerfile-module .`
+
+- Go std:
+    
+        `docker build .`


### PR DESCRIPTION
Go v1.4 was used and as of today Go v1.12 is the latest iteration of it.
It introduces Go modules which allows Go dev to have project outside of
the GOPATH.

Golang now has an official Docker image to help us build
containers. https://hub.docker.com/_/golang which is updated for every
iteration of the language.

It allows us now to have a much simpler Dockerfile containing only what's
required:

- use multistage build to allow container size reduction
- the compiled app is now on a `scratch` base container (no OS)
- it provides a user for security reason
- it provides ca-certs in case it's needed